### PR TITLE
feat(MapViewModel & BottomSheets): Improve map handling, state manage…

### DIFF
--- a/core/common/src/main/java/uz/yalla/client/core/common/maps/MapsViewModel.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/maps/MapsViewModel.kt
@@ -783,7 +783,7 @@ class MapsViewModel(
 
         map?.let { googleMap ->
             locations.forEachIndexed { index, point ->
-                val markerOptions = MarkerOptions().position(LatLng(point.lat, point.lng))
+                val markerOptions = MarkerOptions().position(LatLng(point.lat, point.lng)).zIndex(2f)
 
                 when (index) {
                     0 -> {

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Networking.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Networking.kt
@@ -8,7 +8,6 @@ import uz.yalla.client.core.domain.model.Destination
 import uz.yalla.client.core.domain.model.Location
 import uz.yalla.client.core.domain.model.MapPoint
 import uz.yalla.client.feature.map.domain.model.request.GetRoutingDtoItem
-import uz.yalla.client.feature.order.domain.model.response.order.toCommonExecutor
 import uz.yalla.client.feature.order.presentation.main.view.MainSheetChannel
 import kotlin.math.ceil
 
@@ -153,14 +152,10 @@ fun MViewModel.getRouting() = intent {
 
 
 fun MViewModel.getActiveOrder() = viewModelScope.launch {
-    val orderId = container.stateFlow.value.orderId
-    if (orderId == null) {
-        mapsViewModel.onIntent(MapsIntent.UpdateOrderStatus(null))
-        return@launch
-    }
-    getShowOrderUseCase(orderId).onSuccess { order ->
-        mapsViewModel.onIntent(MapsIntent.UpdateOrderStatus(order.status))
-        intent {
+    intent {
+        val orderId = state.orderId ?: return@intent
+        getShowOrderUseCase(orderId).onSuccess { order ->
+            mapsViewModel.onIntent(MapsIntent.UpdateOrderStatus(order.status))
             reduce {
                 state.copy(
                     order = order,

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+State.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+State.kt
@@ -13,6 +13,7 @@ fun MViewModel.clearState() = intent {
         state.copy(
             order = null,
             orderId = null,
+            location = null,
             destinations = emptyList(),
             route = emptyList(),
             markerState = YallaMarkerState.LOADING
@@ -21,6 +22,11 @@ fun MViewModel.clearState() = intent {
 
     mapsViewModel.onIntent(MapsIntent.UpdateRoute(emptyList()))
     mapsViewModel.onIntent(MapsIntent.UpdateOrderStatus(null))
+    mapsViewModel.onIntent(MapsIntent.UpdateDriver(null))
+    mapsViewModel.onIntent(MapsIntent.UpdateDrivers(emptyList()))
+    mapsViewModel.onIntent(MapsIntent.UpdateOrderEndsInMinutes(null))
+    mapsViewModel.onIntent(MapsIntent.UpdateCarArrivesInMinutes(null))
+    mapsViewModel.onIntent(MapsIntent.UpdateLocations(emptyList()))
 }
 
 

--- a/feature/order/presentation/src/main/java/uz/yalla/client/feature/order/presentation/main/view/sheet/SetBonusAmountBottomSheet.kt
+++ b/feature/order/presentation/src/main/java/uz/yalla/client/feature/order/presentation/main/view/sheet/SetBonusAmountBottomSheet.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -74,7 +73,7 @@ fun SetBonusAmountBottomSheet(
             SetBonusAmountBody(
                 currentBonusAmount = currentBonusAmount,
                 minBonus = minBonus,
-                maxBonus = maxBonus,
+                maxBonus = min(maxBonus, balance),
                 onDecrement = {
                     currentBonusAmount = (currentBonusAmount - CHANGE_AMOUNT)
                         .coerceAtLeast(minBonus)


### PR DESCRIPTION
…ment, and intent flow cancellation

- Added zIndex for markers in `MapsViewModel` to manage render priority.
- Adjusted `SetBonusAmountBottomSheet` to constrain `maxBonus` by user's balance.
- Refactored `getActiveOrder` to simplify null checks and improve state updates.
- Enhanced `clearState` in `MapViewModel` with additional resets for map elements and state intents.
- Introduced `activeCollectorRef` in `MRoute` to manage and cancel active intent flows dynamically.
- Transitioned to `collectLatest` for intent handling in map bottom sheets, ensuring active flow cancellation.