### PR TITLE
feat(SplashScreen & Navigation): Update splash screen logic and adjus…

### DIFF
--- a/.gradle/config.properties
+++ b/.gradle/config.properties
@@ -1,2 +1,2 @@
-#Fri Aug 01 14:43:46 UZT 2025
-java.home=/Users/mac/Applications/Android Studio.app/Contents/jbr/Contents/Home
+#Sun Aug 03 20:09:17 UZT 2025
+java.home=/Applications/Android Studio.app/Contents/jbr/Contents/Home

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,11 +37,15 @@
         <activity
             android:name="uz.yalla.client.activity.MainActivity"
             android:configChanges="locale|layoutDirection|screenSize|smallestScreenSize|screenLayout"
-            android:exported="false"
+            android:exported="true"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:theme="@style/SplashTheme">
+            android:theme="@style/AppTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
 
         <activity
@@ -50,11 +54,6 @@
             android:exported="true"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <meta-data

--- a/app/src/main/java/uz/yalla/client/activity/LoginActivity.kt
+++ b/app/src/main/java/uz/yalla/client/activity/LoginActivity.kt
@@ -33,10 +33,11 @@ import uz.yalla.client.feature.registration.presentation.navigation.registration
 class LoginActivity : AppCompatActivity() {
     private val appPreferences: AppPreferences by inject()
     private val staticPreferences: StaticPreferences by inject()
+    private var keepSplashScreen = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
-
-        installSplashScreen()
+        val splashScreen = installSplashScreen()
+        splashScreen.setKeepOnScreenCondition { keepSplashScreen }
 
         super.onCreate(savedInstanceState)
 
@@ -46,6 +47,7 @@ class LoginActivity : AppCompatActivity() {
                 navigateToMainActivity()
                 return@launch
             }
+            keepSplashScreen = false
         }
 
         enableEdgeToEdge(

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="Theme.AppCompat.NoActionBar">
-    </style>
+
+    <style name="AppTheme" parent="Theme.AppCompat.NoActionBar"></style>
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/splash_background</item>
         <item name="android:statusBarColor">@color/yalla_primary</item>
         <item name="android:navigationBarColor">@color/yalla_primary</item>
+        <item name="postSplashScreenTheme">@style/AppTheme</item>
     </style>
 </resources>


### PR DESCRIPTION
…t activity launch flow

- Integrated splash screen readiness with `keepSplashScreen` in `MainActivity` and `LoginActivity` for smoother transitions.
- Moved launcher intent filter from `LoginActivity` to `MainActivity` and updated `android:exported` for proper activity resolution.
- Introduced `postSplashScreenTheme` in `SplashTheme` for seamless theme switching after splash screen.