### PR TITLE
refactor(Map): Add support for processingOrderId and streamline inten…

### DIFF
--- a/app/src/main/java/uz/yalla/client/activity/MainActivity.kt
+++ b/app/src/main/java/uz/yalla/client/activity/MainActivity.kt
@@ -48,13 +48,12 @@ class MainActivity : ScopeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
-        splashScreen.setKeepOnScreenCondition { keepSplashScreen && !isAppReady.value }
+        splashScreen.setKeepOnScreenCondition { keepSplashScreen || !isAppReady.value }
 
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
-        // Check if user is logged in
+        
         lifecycleScope.launch {
             val accessToken = appPreferences.accessToken.firstOrNull() ?: ""
             if (!staticPreferences.isDeviceRegistered || accessToken.isEmpty()) {

--- a/app/src/main/java/uz/yalla/client/app/App.kt
+++ b/app/src/main/java/uz/yalla/client/app/App.kt
@@ -37,6 +37,7 @@ class App : Application() {
 
         // Set hasProcessedOrderOnEntry to false in StaticPreferences
         staticPreferences.hasProcessedOrderOnEntry = false
+        staticPreferences.processingOrderId = null
         appPreferences.setMapType(MapType.Google)
     }
 }

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/intent/MapIntent.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/intent/MapIntent.kt
@@ -20,4 +20,5 @@ sealed interface MapIntent {
 
     data object OnDismissActiveOrders : MapIntent
     data class SetShowingOrder(val order: ShowOrderModel) : MapIntent
+    data class SetShowingOrderId(val orderId: Int) : MapIntent
 }

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MViewModel.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MViewModel.kt
@@ -69,7 +69,6 @@ class MViewModel(
     internal var hasInjectedOnceInThisSession = false
 
     init {
-        _stateFlow.update { it.copy(orderId = staticPrefs.processingOrderId) }
         startObserve()
         getMe()
         getNotificationsCount()

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Intent.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Intent.kt
@@ -86,6 +86,10 @@ fun MViewModel.onIntent(intent: MapIntent) {
                 )
             }
         }
+
+        is MapIntent.SetShowingOrderId -> {
+            updateState { it.copy(orderId = intent.orderId) }
+        }
     }
 }
 

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/view/MapRoute.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/view/MapRoute.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -126,6 +128,12 @@ fun MRoute(
             if (staticPreferences.isDeviceRegistered.not()) {
                 onNavigate(FromMap.ToRegister)
             }
+        }
+    }
+
+    LaunchedEffect(LocalConfiguration.current) {
+        staticPreferences.processingOrderId?.let { orderId ->
+            viewModel.onIntent(MapIntent.SetShowingOrderId(orderId))
         }
     }
 


### PR DESCRIPTION
…t handling

- Introduced `SetShowingOrderId` intent for managing order IDs.
- Synchronized `processingOrderId` in `StaticPreferences` with `MapViewModel`.
- Adjusted splash screen `setKeepOnScreenCondition` logic for clarity.
- Enhanced `MapRoute` to set `ShowOrderId` intent on configuration change.