### PR TITLE
refactor(Map): Adjust MapViewModel lifecycle, update constants, and s…

### DIFF
--- a/.gradle/config.properties
+++ b/.gradle/config.properties
@@ -1,2 +1,2 @@
-#Mon Aug 04 14:02:27 UZT 2025
-java.home=/Users/mac/Applications/Android Studio.app/Contents/jbr/Contents/Home
+#Tue Aug 05 21:10:40 UZT 2025
+java.home=/Applications/Android Studio.app/Contents/jbr/Contents/Home

--- a/core/common/src/main/java/uz/yalla/client/core/common/maps/MapConstants.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/maps/MapConstants.kt
@@ -14,10 +14,5 @@ object MapConstants {
     const val DASHED_POLYLINE_WIDTH = 4f
 
     const val DEFAULT_ZOOM = 15f
-    const val MIN_ZOOM = 12f
-    const val MAX_ZOOM = 20f
-
-    const val DRIVER_ICON_SIZE = 48
-    const val UPDATE_DEBOUNCE_MS = 100L
-    const val CAMERA_ANIMATION_DURATION = 300
+    const val MIN_ZOOM = 13f
 }

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MViewModel.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import uz.yalla.client.core.common.maps.MapsViewModel
 import uz.yalla.client.core.common.viewmodel.BaseViewModel
@@ -38,7 +37,7 @@ class MViewModel(
     internal val getActiveOrdersUseCase: GetActiveOrdersUseCase,
     internal val getNotificationsCountUseCase: GetNotificationsCountUseCase,
     internal val getSettingUseCase: GetSettingUseCase,
-) : BaseViewModel() {
+) : BaseViewModel(), LifeCycleAware {
 
     private val supervisorJob = SupervisorJob()
     internal val _stateFlow = MutableStateFlow(MapState())
@@ -66,17 +65,15 @@ class MViewModel(
     internal var cancelable = arrayOf<Job>()
     internal val observerScope = CoroutineScope(viewModelScope.coroutineContext + supervisorJob)
 
-    internal var hasInjectedOnceInThisSession = false
-
-    init {
+    override fun onAppear() {
         startObserve()
         getMe()
         getNotificationsCount()
         getSettingConfig()
     }
 
-    override fun onCleared() {
-        super.onCleared()
+    override fun onDisappear() {
+        clearState()
         stopObserve()
     }
 }

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Networking.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Networking.kt
@@ -56,25 +56,15 @@ fun MViewModel.getActiveOrders() {
         val alreadyMarkedAsProcessed = staticPrefs.hasProcessedOrderOnEntry
 
         getActiveOrdersUseCase().onSuccess { activeOrders ->
-            val shouldInject = activeOrders.list.size == 1 &&
-                    !alreadyMarkedAsProcessed &&
-                    !hasInjectedOnceInThisSession
+            val shouldInject = activeOrders.list.size == 1 && !alreadyMarkedAsProcessed
 
             if (shouldInject) {
                 val order = activeOrders.list.first()
-                updateState { state ->
-                    state.copy(
-                        order = order,
-                        orderId = order.id
-                    )
-                }
+                updateState { state -> state.copy(order = order, orderId = order.id) }
                 staticPrefs.hasProcessedOrderOnEntry = true
-                hasInjectedOnceInThisSession = true
-                getActiveOrder()
             } else if (activeOrders.list.size > 1 && !alreadyMarkedAsProcessed) {
                 updateState { state -> state.copy(ordersSheetVisible = true) }
                 staticPrefs.hasProcessedOrderOnEntry = true
-                hasInjectedOnceInThisSession = true
             }
 
             updateState { state -> state.copy(orders = activeOrders.list) }


### PR DESCRIPTION
…implify state handling

- Removed `hasInjectedOnceInThisSession` for streamlined state management.
- Introduced `onAppear` and `onDisappear` in ViewModel for improved lifecycle handling.
- Adjusted `MapConstants` with updated zoom levels.
- Replaced redundant side effects in `MapRoute` with optimized lifecycle event handling.
- Updated `config.properties` for updated JDK path.