### PR TITLE
refactor(Profile): Add navigation to login after logout and enhance s…

### DIFF
--- a/app/src/main/java/uz/yalla/client/navigation/Navigation.kt
+++ b/app/src/main/java/uz/yalla/client/navigation/Navigation.kt
@@ -144,6 +144,7 @@ fun Navigation(
 
         editProfileScreen(
             onBack = navController::navigateToMapScreen,
+            onNavigateToLogin = navigateToLogin
         )
 
         settingsScreen(

--- a/core/data/src/main/java/uz/yalla/client/core/data/local/StaticPreferencesImpl.kt
+++ b/core/data/src/main/java/uz/yalla/client/core/data/local/StaticPreferencesImpl.kt
@@ -42,6 +42,6 @@ class StaticPreferencesImpl(val context: Context) : StaticPreferences {
         preferences.edit { clear() }
         skipOnboarding = true
         hasProcessedOrderOnEntry = true
+        isDeviceRegistered = false
     }
-
 }

--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/view/MapRoute.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/view/MapRoute.kt
@@ -131,7 +131,6 @@ fun MRoute(
     }
 
     LaunchedEffect(Unit) {
-        if (staticPreferences.isDeviceRegistered.not()) onNavigate(FromMap.ToRegister)
         staticPreferences.processingOrderId?.let { orderId ->
             viewModel.onIntent(MapIntent.SetShowingOrderId(orderId))
         }

--- a/feature/profile/presentation/src/main/java/uz/yalla/client/feature/profile/edit_profile/model/EditProfileSideEffect.kt
+++ b/feature/profile/presentation/src/main/java/uz/yalla/client/feature/profile/edit_profile/model/EditProfileSideEffect.kt
@@ -2,6 +2,7 @@ package uz.yalla.client.feature.profile.edit_profile.model
 
 sealed interface EditProfileSideEffect {
     data object NavigateBack : EditProfileSideEffect
+    data object NavigateToLogin : EditProfileSideEffect
     data object ShowImagePicker : EditProfileSideEffect
     data object ShowDeleteConfirmation : EditProfileSideEffect
     data object ClearFocus : EditProfileSideEffect

--- a/feature/profile/presentation/src/main/java/uz/yalla/client/feature/profile/edit_profile/model/EditProfileViewModel+Authentication.kt
+++ b/feature/profile/presentation/src/main/java/uz/yalla/client/feature/profile/edit_profile/model/EditProfileViewModel+Authentication.kt
@@ -8,8 +8,7 @@ fun EditProfileViewModel.logout() = intent {
         logoutUseCase().onSuccess {
             appPreferences.performLogout()
             staticPreferences.performLogout()
+            postSideEffect(EditProfileSideEffect.NavigateToLogin)
         }.onFailure(::handleException)
     }
-
-    postSideEffect(EditProfileSideEffect.NavigateBack)
 }

--- a/feature/profile/presentation/src/main/java/uz/yalla/client/feature/profile/edit_profile/navigation/EditProfileNavigation.kt
+++ b/feature/profile/presentation/src/main/java/uz/yalla/client/feature/profile/edit_profile/navigation/EditProfileNavigation.kt
@@ -11,7 +11,8 @@ import uz.yalla.client.feature.profile.edit_profile.view.EditProfileRoute
 const val EDIT_PROFILE_ROUTE = "edit_profile_route"
 
 fun NavGraphBuilder.editProfileScreen(
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onNavigateToLogin: () -> Unit
 ) {
     composable(
         route = EDIT_PROFILE_ROUTE,
@@ -19,7 +20,8 @@ fun NavGraphBuilder.editProfileScreen(
     ) {
         BackHandler { onBack() }
         EditProfileRoute(
-            onNavigateBack = onBack
+            onNavigateBack = onBack,
+            onNavigateToLogin = onNavigateToLogin
         )
     }
 }


### PR DESCRIPTION
…ide effect handling

- Introduced `NavigateToLogin` side effect to redirect users after logout.
- Updated `EditProfileRoute` to handle the new side effect and navigation flow.
- Adjusted `StaticPreferencesImpl` to reset device registration state.
- Optimized `collectSideEffect` logic in `EditProfileViewModel` for improved readability.