### PR TITLE
refactor(Map): Update driver processing logic and intent handling

### DIFF
--- a/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Networking.kt
+++ b/feature/map/presentation/src/main/java/uz/yalla/client/feature/map/presentation/new_version/model/MapViewModel+Networking.kt
@@ -9,6 +9,7 @@ import uz.yalla.client.core.domain.model.Destination
 import uz.yalla.client.core.domain.model.Location
 import uz.yalla.client.core.domain.model.MapPoint
 import uz.yalla.client.feature.map.domain.model.request.GetRoutingDtoItem
+import uz.yalla.client.feature.order.domain.model.response.order.toCommonExecutor
 import uz.yalla.client.feature.order.presentation.main.view.MainSheetChannel
 import kotlin.math.ceil
 
@@ -62,6 +63,7 @@ fun MViewModel.getActiveOrders() {
             if (shouldInject) {
                 val order = activeOrders.list.first()
                 updateState { state -> state.copy(order = order, orderId = order.id) }
+                mapsViewModel.onIntent(MapsIntent.UpdateDriver(order.executor.toCommonExecutor()))
                 prefs.setHasProcessedOrderOnEntry(true)
             } else if (activeOrders.list.size > 1 && !alreadyMarkedAsProcessed) {
                 updateState { state -> state.copy(ordersSheetVisible = true) }
@@ -150,6 +152,7 @@ fun MViewModel.getActiveOrder() = viewModelScope.launch {
     }
     getShowOrderUseCase(orderId).onSuccess { order ->
         mapsViewModel.onIntent(MapsIntent.UpdateOrderStatus(order))
+        mapsViewModel.onIntent(MapsIntent.UpdateDriver(order.executor.toCommonExecutor()))
         updateState { state ->
             state.copy(
                 order = order,


### PR DESCRIPTION
- Introduced `UpdateDriver` intent in `MapViewModel` for consistent driver updates.
- Enhanced state updates by integrating `toCommonExecutor` mapping for order executors.
- Improved intent handling across multiple order-related use cases.