### PR TITLE
fix(workflow): correct version code calculation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,9 @@ jobs:
         id: version_code
         run: |
           BASE_VERSION=50
-         _CODE=$((BASE_VERSION + ${{ github.run_number }}))
-          echo "VERSION_CODE=_CODE" >> $GITHUB_OUTPUT
-          echo "New version code will be: _CODE"
+          NEW_VERSION_CODE=$((BASE_VERSION + ${{ github.run_number }}))
+          echo "VERSION_CODE=$NEW_VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "New version code will be: $NEW_VERSION_CODE"
 
       - name: Version Bump
         uses: chkfung/android-version-actions@v1.2.2


### PR DESCRIPTION
- Fixed variable assignment error that caused incorrect version code output.
- Ensured `$GITHUB_OUTPUT` receives the properly calculated `NEW_VERSION_CODE`.