### PR TITLE
refactor(maps): migrate to official MapLibre Compose library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,3 @@ plugins {
     alias(libs.plugins.android.test) apply false
     alias(libs.plugins.google.android.libraries.mapsplatform.secrets.gradle.plugin) apply false
 }
-
-configurations.all {
-    exclude(group = "org.jogamp.gluegen", module = "gluegen-rt")
-    exclude(group = "org.jogamp.jogl", module = "jogl-all")
-    exclude(group = "dev.datlag", module = "jcef")
-    exclude(group = "dev.datlag", module = "kcef")
-}

--- a/core/common/src/main/java/uz/yalla/client/core/common/map/extended/google/GoogleMap+Elements.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/map/extended/google/GoogleMap+Elements.kt
@@ -178,7 +178,7 @@ fun GoogleDriver(
 fun GoogleDriversWithAnimation(
     drivers: List<Executor>
 ) {
-    drivers.take(20).forEach { driver ->
+    drivers.take(10).forEach { driver ->
         key(driver.id) {
             val markerState = rememberMarkerState(key = driver.id.toString())
 
@@ -235,8 +235,7 @@ fun GoogleDriversWithAnimation(
                 }
             }
 
-            markerState.position =
-                LatLng(animatedLat.value.toDouble(), animatedLng.value.toDouble())
+            markerState.position = LatLng(animatedLat.value.toDouble(), animatedLng.value.toDouble())
 
             MarkerComposable(
                 state = markerState,

--- a/core/common/src/main/java/uz/yalla/client/core/common/map/extended/libre/LibreMap+Camera.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/map/extended/libre/LibreMap+Camera.kt
@@ -1,9 +1,9 @@
 package uz.yalla.client.core.common.map.extended.libre
 
 import androidx.compose.foundation.layout.PaddingValues
-import dev.sargunv.maplibrecompose.compose.CameraState
-import dev.sargunv.maplibrecompose.core.CameraPosition
 import io.github.dellisd.spatialk.geojson.Position
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
 import uz.yalla.client.core.common.map.core.MapConstants
 import uz.yalla.client.core.common.map.core.toBoundingBox
 import uz.yalla.client.core.domain.model.MapPoint

--- a/core/common/src/main/java/uz/yalla/client/core/common/map/extended/libre/LibreMap.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/map/extended/libre/LibreMap.kt
@@ -8,18 +8,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sargunv.maplibrecompose.compose.MaplibreMap
-import dev.sargunv.maplibrecompose.compose.rememberCameraState
-import dev.sargunv.maplibrecompose.core.CameraMoveReason
-import dev.sargunv.maplibrecompose.core.CameraPosition
-import dev.sargunv.maplibrecompose.core.GestureSettings
-import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.maplibre.compose.camera.CameraMoveReason
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.map.GestureOptions
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.OrnamentOptions
+import org.maplibre.compose.style.BaseStyle
 import org.orbitmvi.orbit.compose.collectSideEffect
 import uz.yalla.client.core.common.map.core.MapConstants
 import uz.yalla.client.core.common.map.core.MarkerState
@@ -85,7 +87,7 @@ class LibreMap : Map {
         }
 
         LaunchedEffect(camera) {
-            camera.awaitInitialized()
+            camera.awaitProjection()
             delay(100)
             if (!mapReadyEmitted) {
                 mapReadyEmitted = true
@@ -211,25 +213,29 @@ class LibreMap : Map {
         MaplibreMap(
             cameraState = camera,
             zoomRange = MapConstants.ZOOM_MIN_ZOOM..MapConstants.ZOOM_MAX_ZOOM,
-            styleUri = if (effectiveTheme == ThemeType.DARK) {
-                "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
-            } else {
-                "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-            },
-            ornamentSettings = OrnamentSettings(
-                padding = state.viewPadding,
-                isLogoEnabled = true,
-                logoAlignment = Alignment.BottomStart,
-                isAttributionEnabled = false,
-                isCompassEnabled = false,
-                isScaleBarEnabled = false
+            baseStyle = BaseStyle.Uri(
+                if (effectiveTheme == ThemeType.DARK) {
+                    "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+                } else {
+                    "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+                }
             ),
-            gestureSettings = GestureSettings(
-                isScrollGesturesEnabled = state.orderStatus !in OrderStatus.nonInteractive,
-                isZoomGesturesEnabled = state.orderStatus !in OrderStatus.nonInteractive,
-                isRotateGesturesEnabled = false,
-                isTiltGesturesEnabled = false,
-                isKeyboardGesturesEnabled = false
+            options = MapOptions(
+                gestureOptions = GestureOptions(
+                    isRotateEnabled = false,
+                    isScrollEnabled = state.orderStatus !in OrderStatus.nonInteractive,
+                    isZoomEnabled = state.orderStatus !in OrderStatus.nonInteractive,
+                    isQuickZoomEnabled = state.orderStatus !in OrderStatus.nonInteractive,
+                    isTiltEnabled = false
+                ),
+                ornamentOptions = OrnamentOptions(
+                    padding = state.viewPadding,
+                    isLogoEnabled = true,
+                    logoAlignment = Alignment.BottomStart,
+                    isAttributionEnabled = false,
+                    isCompassEnabled = false,
+                    isScaleBarEnabled = false
+                )
             ),
             modifier = Modifier.onSizeChanged {
                 animationScope.launch {

--- a/core/common/src/main/java/uz/yalla/client/core/common/map/lite/libre/LiteLibreMap.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/map/lite/libre/LiteLibreMap.kt
@@ -7,18 +7,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sargunv.maplibrecompose.compose.MaplibreMap
-import dev.sargunv.maplibrecompose.compose.rememberCameraState
-import dev.sargunv.maplibrecompose.core.CameraMoveReason
-import dev.sargunv.maplibrecompose.core.CameraPosition
-import dev.sargunv.maplibrecompose.core.GestureSettings
-import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.maplibre.compose.camera.CameraMoveReason
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.map.GestureOptions
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.OrnamentOptions
+import org.maplibre.compose.style.BaseStyle
 import org.orbitmvi.orbit.compose.collectSideEffect
 import uz.yalla.client.core.common.map.core.MapConstants
 import uz.yalla.client.core.common.map.core.MarkerState
@@ -85,7 +87,7 @@ class LiteLibreMap : LiteMap {
         }
 
         LaunchedEffect(camera) {
-            camera.awaitInitialized()
+            camera.awaitProjection()
             delay(100)
             if (!mapReadyEmitted) {
                 mapReadyEmitted = true
@@ -147,25 +149,29 @@ class LiteLibreMap : LiteMap {
             modifier = modifier,
             cameraState = camera,
             zoomRange = MapConstants.ZOOM_MIN_ZOOM..MapConstants.ZOOM_MAX_ZOOM,
-            styleUri = if (effectiveTheme == ThemeType.DARK) {
-                "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
-            } else {
-                "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-            },
-            ornamentSettings = OrnamentSettings(
-                padding = state.viewPadding,
-                isLogoEnabled = true,
-                logoAlignment = Alignment.BottomStart,
-                isAttributionEnabled = false,
-                isCompassEnabled = false,
-                isScaleBarEnabled = false
+            baseStyle = BaseStyle.Uri(
+                if (effectiveTheme == ThemeType.DARK) {
+                    "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+                } else {
+                    "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+                }
             ),
-            gestureSettings = GestureSettings(
-                isScrollGesturesEnabled = true,
-                isZoomGesturesEnabled = true,
-                isRotateGesturesEnabled = false,
-                isTiltGesturesEnabled = false,
-                isKeyboardGesturesEnabled = false
+            options = MapOptions(
+                ornamentOptions = OrnamentOptions(
+                    padding = state.viewPadding,
+                    isLogoEnabled = true,
+                    logoAlignment = Alignment.BottomStart,
+                    isAttributionEnabled = false,
+                    isCompassEnabled = false,
+                    isScaleBarEnabled = false
+                ),
+                gestureOptions = GestureOptions(
+                    isScrollEnabled = true,
+                    isZoomEnabled = true,
+                    isQuickZoomEnabled = true,
+                    isRotateEnabled = false,
+                    isTiltEnabled = false,
+                )
             )
         )
     }

--- a/core/common/src/main/java/uz/yalla/client/core/common/map/static/libre/StaticLibreMap.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/map/static/libre/StaticLibreMap.kt
@@ -2,26 +2,22 @@ package uz.yalla.client.core.common.map.static.libre
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.sargunv.maplibrecompose.compose.MaplibreMap
-import dev.sargunv.maplibrecompose.compose.rememberCameraState
-import dev.sargunv.maplibrecompose.core.CameraPosition
-import dev.sargunv.maplibrecompose.core.GestureSettings
-import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.map.GestureOptions
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.OrnamentOptions
+import org.maplibre.compose.style.BaseStyle
 import org.orbitmvi.orbit.compose.collectSideEffect
 import uz.yalla.client.core.common.map.core.MapConstants
 import uz.yalla.client.core.common.map.extended.libre.LibreMarkers
@@ -64,7 +60,7 @@ class StaticLibreMap : StaticMap {
         var mapReadyEmitted by remember { mutableStateOf(false) }
 
         LaunchedEffect(camera) {
-            camera.awaitInitialized()
+            camera.awaitProjection()
             delay(100)
             if (!mapReadyEmitted) {
                 mapReadyEmitted = true
@@ -106,24 +102,28 @@ class StaticLibreMap : StaticMap {
             modifier = modifier,
             cameraState = camera,
             zoomRange = MapConstants.ZOOM_MIN_ZOOM..MapConstants.ZOOM_MAX_ZOOM,
-            styleUri = if (effectiveTheme == ThemeType.DARK) {
-                "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
-            } else {
-                "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-            },
-            ornamentSettings = OrnamentSettings(
-                isLogoEnabled = true,
-                logoAlignment = Alignment.BottomStart,
-                isAttributionEnabled = false,
-                isCompassEnabled = false,
-                isScaleBarEnabled = false
+            baseStyle = BaseStyle.Uri(
+                if (effectiveTheme == ThemeType.DARK) {
+                    "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+                } else {
+                    "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+                }
             ),
-            gestureSettings = GestureSettings(
-                isScrollGesturesEnabled = false,
-                isZoomGesturesEnabled = true,
-                isRotateGesturesEnabled = false,
-                isTiltGesturesEnabled = false,
-                isKeyboardGesturesEnabled = false
+            options = MapOptions(
+                ornamentOptions = OrnamentOptions(
+                    isLogoEnabled = true,
+                    logoAlignment = Alignment.BottomStart,
+                    isAttributionEnabled = false,
+                    isCompassEnabled = false,
+                    isScaleBarEnabled = false
+                ),
+                gestureOptions = GestureOptions(
+                    isScrollEnabled = false,
+                    isZoomEnabled = true,
+                    isQuickZoomEnabled = true,
+                    isRotateEnabled = false,
+                    isTiltEnabled = false
+                )
             )
         ) {
             LibreMarkers(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ firebaseBom = "33.12.0"
 inspektifyKtor2 = "1.0.0-beta09"
 junit = "4.13.2"
 junitVersion = "1.2.1"
-kotlin = "2.0.0"
+kotlin = "2.2.0"
 compose = "1.9.1"
 compose-material3 = "1.3.1"
 compose-material = "1.12.0"
@@ -53,7 +53,7 @@ jetbrainsKotlinJvm = "2.0.20"
 firebaseCrashlytics = "3.0.3"
 googleServices = "4.4.1"
 datastore = "1.1.4"
-mapLibre = "0.7.0"
+mapLibre = "0.11.1"
 espressoCore = "3.6.1"
 uiautomator = "2.2.0"
 benchmarkMacroJunit4 = "1.2.0-beta01"
@@ -143,7 +143,7 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
 datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
-maplibre-compose = { module = "dev.sargunv.maplibre-compose:maplibre-compose", version.ref = "mapLibre" }
+maplibre-compose = { module = "org.maplibre.compose:maplibre-compose", version.ref = "mapLibre" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacroJunit4" }


### PR DESCRIPTION
- Update MapLibre Compose dependency from dev.sargunv to org.maplibre.compose (v0.11.1)
- Migrate API calls to new library structure (CameraState, MapOptions, GestureOptions)
- Replace deprecated styleUri with BaseStyle.Uri for map styling
- Update GeoJSON data creation using new GeoJsonData.Features API
- Optimize driver animation performance by limiting visible drivers to 10
- Remove unnecessary Kotlin version upgrade and build configuration exclusions
- Maintain feature parity across all map implementations (static, extended, lite)