### PR TITLE
fix(ui): improve sheet appearance and system bar handling

### DIFF
--- a/core/common/src/main/java/uz/yalla/client/core/common/sheet/search_address/SearchByNameBottomSheet.kt
+++ b/core/common/src/main/java/uz/yalla/client/core/common/sheet/search_address/SearchByNameBottomSheet.kt
@@ -188,7 +188,7 @@ fun SearchByNameBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(.8f)
-                .clip(RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp))
+                .clip(RoundedCornerShape(30.dp))
                 .background(YallaTheme.color.background)
         ) {
             when {

--- a/feature/order/presentation/src/main/java/uz/yalla/client/feature/order/presentation/cancel_reason/view/CancelReasonSheet.kt
+++ b/feature/order/presentation/src/main/java/uz/yalla/client/feature/order/presentation/cancel_reason/view/CancelReasonSheet.kt
@@ -13,7 +13,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -24,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -68,6 +73,7 @@ fun CancelReasonSheet(
                     CancelReasonSheetChannel.sendIntent(CancelReasonIntent.NavigateBack)
                     false
                 }
+
                 CancelReasonActionState.GettingSuccess -> false
                 CancelReasonActionState.Loading -> true
                 CancelReasonActionState.SettingSuccess -> {
@@ -87,22 +93,32 @@ fun CancelReasonSheet(
         sheetDragHandle = null,
         sheetContainerColor = YallaTheme.color.surface,
         content = {},
+        sheetShape = RectangleShape,
         sheetContent = {
             Column(
                 modifier = Modifier
-                    .background(
-                        color = YallaTheme.color.background,
-                        shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)
-                    )
+                    .background(YallaTheme.color.background)
                     .padding(top = 20.dp)
                     .navigationBarsPadding()
             ) {
+                IconButton(
+                    onClick = {
+                        CancelReasonSheetChannel.sendIntent(CancelReasonIntent.NavigateBack)
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                        contentDescription = null,
+                        tint = YallaTheme.color.onBackground
+                    )
+                }
+
                 CancelReasonInfo()
 
                 CancelReasons(
                     reasons = uiState.reasons,
                     selectedReason = uiState.selectedReason,
-                    onSelectReason = { 
+                    onSelectReason = {
                         viewModel.updateSelectedReason(it)
                     }
                 )


### PR DESCRIPTION
- Updated `SearchByNameBottomSheet` to use `RoundedCornerShape(30.dp)` for all corners instead of just top corners.
- Modified `MainActivity` to dynamically set system bar style (status and navigation) based on the app's theme (light/dark) and system theme preference. It now collects `appPreferences.themeType` and adjusts `SystemBarStyle` accordingly within a `repeatOnLifecycle` block.
- Added `isSystemDark()` utility function to `MainActivity` to check the current system UI mode.
- In `CancelReasonSheet`:
    - Changed sheet background shape to `RectangleShape` (effectively removing rounded corners for the sheet itself).
    - Added a back arrow `IconButton` at the top of the sheet content for navigation.
    - Ensured the content within the sheet (`Column`) still has a background with `RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)` applied via its `background` modifier.
    - Removed `sheetDragHandle` and set `sheetContainerColor` to `YallaTheme.color.surface`.